### PR TITLE
Add browserify dev-dep

### DIFF
--- a/lib/package.json
+++ b/lib/package.json
@@ -26,6 +26,7 @@
     "gulp-uglify": "~0.3.1",
     "gulp-jshint": "~1.6.3",
     "vinyl-source-stream": "~0.1.1",
-    "gulp-streamify": "0.0.5"
+    "gulp-streamify": "0.0.5",
+    "browserify": "4.2.3"
   }
 }


### PR DESCRIPTION
We can't use the latest version of browserify b/c the latest version has changed the node.js api b/c browserify is a tool for children. It's probably a global dep on your machine?
